### PR TITLE
Change shift left operator to exponent operator to avoid overflow

### DIFF
--- a/calculations_4.js
+++ b/calculations_4.js
@@ -36,7 +36,7 @@ function network_address_4(ip, mask) {
 }
 
 function subnet_addresses_4(mask) {
-    return 1 << (32 - mask);
+    return 2 ** (32 - mask);
 }
 
 function subnet_first_address_useable_4(addrint) {


### PR DESCRIPTION
Large numbers of IPv4 hosts (/0 and /1 subnets) are overflowing and showing as a negative number.  Changing 1<<(32-mask) to 2**(32-mask) causes JavaScript to calculate the integer properly.